### PR TITLE
fix: 🐛 Corrige verificação de coordenadas no componente Map para evit…

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -89,11 +89,16 @@ const Map: React.FC<MapProps> = ({
 
   useEffect(() => {
     const grouped = properties.reduce((acc, property) => {
-      const key = `${property.coords.lat}-${property.coords.lon}`;
-      if (!acc[key]) {
-        acc[key] = [];
+      if (
+        property.coords?.lat !== undefined &&
+        property.coords?.lon !== undefined
+      ) {
+        const key = `${property.coords.lat}-${property.coords.lon}`;
+        if (!acc[key]) {
+          acc[key] = [];
+        }
+        acc[key].push(property);
       }
-      acc[key].push(property);
       return acc;
     }, {} as { [key: string]: Property[] });
 


### PR DESCRIPTION
This pull request includes a small but important change to the `Map` component in the `src/components/Map/Map.tsx` file. The change adds a check to ensure that the `coords` property of each `property` object has defined `lat` and `lon` values before grouping the properties.

* [`src/components/Map/Map.tsx`](diffhunk://#diff-b487e801caeeea9b84099fa69f635c4003957aeba832508d65456b022bcff843R92-R101): Added a check to ensure `property.coords.lat` and `property.coords.lon` are defined before grouping properties.…ar erros ao agrupar propriedades