### PR TITLE
Fix layout issues in property cards and list container

### DIFF
--- a/src/components/PropertyCard/PropertyCard.tsx
+++ b/src/components/PropertyCard/PropertyCard.tsx
@@ -115,7 +115,7 @@ const PropertyCard: React.FC<PropertyCardProps> = memo(
     };
 
     return (
-      <div className="card w-96 bg-base-100 shadow-xl">
+      <div className="card w-80 bg-base-100 shadow-xl">
         <figure>
           <div className="carousel w-full">{renderCarousel()}</div>
         </figure>

--- a/src/components/PropertyList/PropertyList.tsx
+++ b/src/components/PropertyList/PropertyList.tsx
@@ -91,13 +91,12 @@ const PropertyList: React.FC<PropertyListProps> = ({
   }, [loadMoreItems]);
 
   return (
-    <div className="flex flex-wrap justify-start gap-4">
+    <div className="h-[calc(100vh-8rem)] overflow-y-auto flex flex-wrap justify-start gap-4">
       {visibleProperties.map((property, index) => (
-        <div key={index} className="  h-auto p-2">
+        <div key={index} className="h-auto p-2">
           <PropertyCard property={property} index={index} />
         </div>
       ))}
-
       <div ref={observerRef} className="w-full h-1"></div>
     </div>
   );

--- a/src/components/PropertyList/PropertyList.tsx
+++ b/src/components/PropertyList/PropertyList.tsx
@@ -93,7 +93,7 @@ const PropertyList: React.FC<PropertyListProps> = ({
   return (
     <div className="flex flex-wrap justify-start gap-4">
       {visibleProperties.map((property, index) => (
-        <div key={index} className="w-64 h-auto p-2">
+        <div key={index} className="  h-auto p-2">
           <PropertyCard property={property} index={index} />
         </div>
       ))}

--- a/src/hooks/useFilteredHouses.ts
+++ b/src/hooks/useFilteredHouses.ts
@@ -52,9 +52,10 @@ const useFilteredHouses = (
         rooms >= filters.numberOfRooms &&
         bathrooms >= filters.numberOfBathrooms &&
         parking >= filters.numberOfParkingSpaces &&
+        house?.address &&
         house.address
           .toLowerCase()
-          .includes(filters.addressQuery.toLowerCase()) &&
+          .includes(filters?.addressQuery?.toLowerCase()) &&
         isWithinSelectedDistance
       );
     });

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import PropertyNavbarFilters from "../../components/Filters/PropertyNavbarFilters";
 import Map from "../../components/Map/Map";
@@ -11,7 +11,7 @@ import useFilteredHouses from "../../hooks/useFilteredHouses";
 import { DataPops } from "../../services/dataService";
 
 const Home = () => {
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [isModalOpen, setIsModalOpen] = useState(true);
   const [showMap, setShowMap] = useState(false);
   const [houseList, setHouseList] = useState<DataPops["olxResults"]>([]);
@@ -74,11 +74,7 @@ const Home = () => {
 
   const HouseListRendered = useMemo(() => {
     if (!loading) {
-      return (
-        <div className="flex">
-          <PropertyList properties={filteredHouseList} />
-        </div>
-      );
+      return <PropertyList properties={filteredHouseList} />;
     }
     return <>{Skeleton}</>;
   }, [loading, filteredHouseList]);
@@ -109,8 +105,9 @@ const Home = () => {
           setActiveTags={setSelectedDistances}
         /> */}
         <div
-          className="flex flex-wrap justify-between gap-2 p-5 lg:w-2/3"
-          ref={scrollContainerRef}
+          className={`flex flex-wrap justify-between gap-2 p-5 ${
+            showMap ? "lg:w-2/3" : "lg:w-full"
+          }`} // ref={scrollContainerRef}
         >
           {loading && <p>Carregando...</p>}
           {!loading && hasData && filteredHouseList.length === 0 && (


### PR DESCRIPTION
Adjust the width of the property card and the height of the property list container to ensure proper scrolling functionality. Remove unused references in the Home component.