### PR TITLE
Adjust map container and property list height for better layout

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -109,7 +109,7 @@ const Map: React.FC<MapProps> = ({
     <MapContainer
       center={position || defaultCenter}
       zoom={13}
-      style={{ height: "100vh", width: "100%" }}
+      style={{ height: "84vh", width: "100%", overflow: "hidden" }}
     >
       <TileLayer
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/src/components/PropertyList/PropertyList.tsx
+++ b/src/components/PropertyList/PropertyList.tsx
@@ -91,7 +91,7 @@ const PropertyList: React.FC<PropertyListProps> = ({
   }, [loadMoreItems]);
 
   return (
-    <div className="h-[calc(100vh-8rem)] overflow-y-auto flex flex-wrap justify-start gap-4">
+    <div className="h-[calc(90vh-8rem)] overflow-y-auto flex flex-wrap justify-center mx-auto gap-4">
       {visibleProperties.map((property, index) => (
         <div key={index} className="h-auto p-2">
           <PropertyCard property={property} index={index} />


### PR DESCRIPTION
Modify the height of the map container and property list to enhance scrolling and overall layout.